### PR TITLE
Create config file even if database gets applied

### DIFF
--- a/docker/image/console/root/lib/task/init.sh
+++ b/docker/image/console/root/lib/task/init.sh
@@ -3,6 +3,7 @@
 function task_init()
 {
     task "mysql:available"
+    task "wordpress:configfile"
     task "assets:apply"
     task "welcome"
 }

--- a/docker/image/console/root/lib/task/skeleton/apply.sh
+++ b/docker/image/console/root/lib/task/skeleton/apply.sh
@@ -2,10 +2,5 @@
 
 function task_skeleton_apply()
 {
-    if [ "${PHP_VERSION:0:3}" == "5.6" ]; then
-      mv /home/build/skeleton/composer-5.6.json /home/build/skeleton/composer.json
-    else
-      rm -f /home/build/skeleton/composer-5.6.json
-    fi
     run "rsync --exclude='*.twig' --ignore-existing -a /home/build/skeleton/ /app/"
 }

--- a/docker/image/console/root/lib/task/wordpress/configfile.sh
+++ b/docker/image/console/root/lib/task/wordpress/configfile.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function task_wordpress_configfile()
+{
+    if [ -f "${WORDPRESS_INSTALL_DIRECTORY}/wp-config.php" ]; then
+        return 0
+    fi
+
+    passthru "bin/wp-cli.phar config create \
+        --path='${WORDPRESS_INSTALL_DIRECTORY}' \
+        --dbname='${DB_NAME}' \
+        --dbhost='${DB_HOST}' \
+        --dbuser='${DB_USER}' \
+        --dbpass='${DB_PASS}'"
+}

--- a/docker/image/console/root/lib/task/wordpress/install.sh
+++ b/docker/image/console/root/lib/task/wordpress/install.sh
@@ -2,13 +2,6 @@
 
 function task_wordpress_install()
 {
-    passthru "bin/wp-cli.phar config create \
-        --path='${WORDPRESS_INSTALL_DIRECTORY}' \
-        --dbname='${DB_NAME}' \
-        --dbhost='${DB_HOST}' \
-        --dbuser='${DB_USER}' \
-        --dbpass='${DB_PASS}'"
-
     task "mysql:available"
 
     passthru "bin/wp-cli.phar core install \


### PR DESCRIPTION
Fixes the following command failing after `assets:apply`:
```
■ > bin/wp-cli.phar --path='/app/public/' option update siteurl https://example.my127.site/
Error: 'wp-config.php' not found.
Either create one manually or use `wp config create`.
```