### PR TITLE
Fix multiple environments being load balanced

### DIFF
--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -9,14 +9,18 @@ services:
 {% endif %}
   chrome:
     build: docker/image/chrome
-    networks:
-      - shared
-      - private
     environment:
       HOST_OS_FAMILY: ${HOST_OS_FAMILY}
       APP_HOST: ${APP_HOST}
     labels:
       - traefik.enable=false
+    networks:
+      private:
+        aliases:
+          - chrome
+      shared:
+        aliases:
+          - {{ @('namespace') }}_chrome
   console:
 {% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.dynamic.sh
@@ -72,8 +76,15 @@ services:
     depends_on:
       - php-fpm
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - nginx
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_nginx
+      shared:
+        aliases:
+          - {{ @('namespace') }}_nginx
   php-fpm:
     build: docker/image/php-fpm
 {% if @('app.build') == 'dynamic' %}
@@ -84,8 +95,12 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - php-fpm
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_php-fpm
     depends_on:
       - console
     environment:
@@ -105,11 +120,18 @@ services:
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
     networks:
-      - private
-      - shared
+      private:
+        aliases:
+          - mysql
+      monitoring:
+        aliases:
+          - {{ @('namespace') }}_mysql
 networks:
   private:
     external: false
+  monitoring:
+    external:
+      name: my127ws_monitoring
   shared:
     external:
       name: my127ws

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -15,12 +15,8 @@ services:
     labels:
       - traefik.enable=false
     networks:
-      private:
-        aliases:
-          - chrome
-      shared:
-        aliases:
-          - {{ @('namespace') }}_chrome
+      - private
+      - shared
   console:
 {% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.dynamic.sh
@@ -58,8 +54,8 @@ services:
       WORDPRESS_NONCE_SALT: ${WORDPRESS_NONCE_SALT}
     networks:
       - private
-    depends_on:
-      - mysql
+    links:
+      - mysql:mysql
   nginx:
     build: docker/image/nginx
 {% if @('app.build') == 'dynamic' %}
@@ -73,18 +69,12 @@ services:
       - traefik.port=80
       - co.elastic.logs/module=nginx
       - co.elastic.metrics/module=nginx
-    depends_on:
-      - php-fpm
+    links:
+      - php-fpm:php-fpm
     networks:
-      private:
-        aliases:
-          - nginx
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_nginx
-      shared:
-        aliases:
-          - {{ @('namespace') }}_nginx
+      - private
+      - monitoring
+      - shared
   php-fpm:
     build: docker/image/php-fpm
 {% if @('app.build') == 'dynamic' %}
@@ -94,15 +84,13 @@ services:
 {% endif %}
     labels:
       - traefik.enable=false
-    networks:
-      private:
-        aliases:
-          - php-fpm
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_php-fpm
     depends_on:
       - console
+    links:
+      - mysql:mysql
+    networks:
+      - private
+      - monitoring
     environment:
       <<: *APP_ENV_VARS
   mysql:
@@ -120,12 +108,8 @@ services:
       - MYSQL_USER=${DB_USER}
       - MYSQL_PASSWORD=${DB_PASS}
     networks:
-      private:
-        aliases:
-          - mysql
-      monitoring:
-        aliases:
-          - {{ @('namespace') }}_mysql
+      - private
+      - monitoring
 networks:
   private:
     external: false

--- a/docker-compose.yml.twig
+++ b/docker-compose.yml.twig
@@ -18,21 +18,21 @@ services:
       - private
       - shared
   console:
-{% if @('app.build') == 'dynamic' %}
+{% if @('app.build') == 'dynamic' %} 
     entrypoint: /entrypoint.dynamic.sh
     volumes:
       - {{ (dockersync) ? @('workspace.name') ~ '-sync:/app:nocopy' : '../:/app:delegated' }}
       - ./skeleton:/home/build/skeleton
-{% endif %}
+{% endif %} 
     labels:
       - traefik.enable=false
     build:
       context: ../
       dockerfile: .my127ws/docker/image/console/Dockerfile
-{% if @('app.build') == 'static' %}
+{% if @('app.build') == 'static' %} 
       args:
         APP_MODE: {{ @('app.mode') }}
-{% endif %}
+{% endif %} 
     environment: &APP_ENV_VARS
       HOST_OS_FAMILY: ${HOST_OS_FAMILY}
       APP_NAME: ${APP_NAME}
@@ -58,10 +58,10 @@ services:
       - mysql:mysql
   nginx:
     build: docker/image/nginx
-{% if @('app.build') == 'dynamic' %}
+{% if @('app.build') == 'dynamic' %} 
     volumes:
       - {{ (dockersync) ? @('workspace.name') ~ '-sync:/app:nocopy' : '../:/app:delegated' }}
-{% endif %}
+{% endif %} 
     labels:
       - traefik.backend=${APP_NAME}
       - traefik.frontend.rule=Host:${APP_HOST}
@@ -73,15 +73,14 @@ services:
       - php-fpm:php-fpm
     networks:
       - private
-      - monitoring
       - shared
   php-fpm:
     build: docker/image/php-fpm
-{% if @('app.build') == 'dynamic' %}
+{% if @('app.build') == 'dynamic' %} 
     entrypoint: /entrypoint.dynamic.sh
     volumes:
       - {{ (dockersync) ? @('workspace.name') ~ '-sync:/app:nocopy' : '../:/app:delegated' }}
-{% endif %}
+{% endif %} 
     labels:
       - traefik.enable=false
     depends_on:
@@ -90,7 +89,7 @@ services:
       - mysql:mysql
     networks:
       - private
-      - monitoring
+      - shared
     environment:
       <<: *APP_ENV_VARS
   mysql:
@@ -109,13 +108,10 @@ services:
       - MYSQL_PASSWORD=${DB_PASS}
     networks:
       - private
-      - monitoring
+      - shared
 networks:
   private:
     external: false
-  monitoring:
-    external:
-      name: my127ws_monitoring
   shared:
     external:
       name: my127ws

--- a/docker/image/console/root/lib/sidekick.sh
+++ b/docker/image/console/root/lib/sidekick.sh
@@ -33,14 +33,14 @@ prompt()
 
 run()
 {
+    local COMMAND="$*"
     if [ "$VERBOSE" = "no" ]; then
         prompt
 
-        echo "  > $*"
+        echo "  > ${COMMAND[*]}"
         setCommandIndicator $INDICATOR_RUNNING
-        bash -c "$@" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt
 
-        if [ "$?" != "0" ]; then
+        if ! bash -c "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt; then
             setCommandIndicator $INDICATOR_ERROR
 
             cat /tmp/my127ws-stderr.txt
@@ -55,7 +55,7 @@ run()
             setCommandIndicator $INDICATOR_SUCCESS
         fi
     else
-        passthru "$@"
+        passthru "${COMMAND[@]}"
     fi
 }
 


### PR DESCRIPTION
Traefik talks to `nginx` in the `my127ws` namespace.

If two environments are running at once, the `nginx` DNS address is load balanced between the two environments.

Also use a separate namespace for monitoring.